### PR TITLE
Enable smartypants for curly quotes, ... ellipsis, -- en dash, --- em…

### DIFF
--- a/src/md.js
+++ b/src/md.js
@@ -5,7 +5,7 @@ export default function(require) {
         var string = strings[0] + "", i = 0, n = arguments.length;
         while (++i < n) string += arguments[i] + "" + strings[i];
         var root = document.createElement("div");
-        root.innerHTML = marked(string, {langPrefix: ""}).trim();
+        root.innerHTML = marked(string, {langPrefix: "", smartypants: true}).trim();
         var code = root.querySelectorAll("pre code[class]");
         if (code.length > 0) require("@observablehq/highlight.js@1.0.0/highlight.min.js").then(function(hl) { code.forEach(hl.highlightBlock); });
         return root.childNodes.length === 1 ? root.removeChild(root.firstChild) : root;


### PR DESCRIPTION
… dash.

Fixes https://github.com/observablehq/notebook-runtime/issues/73 - saves us seconds or perhaps hours of meticulously curling quotes.