### PR TITLE
Don’t generate document fragments.

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -3,5 +3,9 @@ import template from "./template";
 export default template(function(string) {
   var template = document.createElement("template");
   template.innerHTML = string;
-  return template.content;
+  var content = template.content;
+  if (content.childNodes.length === 1) return content;
+  var div = document.createElement("div");
+  div.appendChild(content);
+  return div;
 });

--- a/src/html.js
+++ b/src/html.js
@@ -2,7 +2,7 @@ import template from "./template";
 
 export default template(function(string) {
   var template = document.createElement("template");
-  template.innerHTML = string;
+  template.innerHTML = string.trim();
   var content = template.content;
   if (content.childNodes.length === 1) return content;
   var div = document.createElement("div");

--- a/src/md.js
+++ b/src/md.js
@@ -4,11 +4,11 @@ export default function(require) {
   return function() {
     return require("marked@0.3.12/marked.min.js").then(function(marked) {
       return template(function(string) {
-        var template = document.createElement("template");
-        template.innerHTML = marked(string, {langPrefix: ""}).trim();
-        var code = template.content.querySelectorAll("pre code[class]");
+        var root = document.createElement("div");
+        root.innerHTML = marked(string, {langPrefix: ""}).trim();
+        var code = root.querySelectorAll("pre code[class]");
         if (code.length > 0) require("@observablehq/highlight.js@1.0.0/highlight.min.js").then(function(hl) { code.forEach(hl.highlightBlock); });
-        return template.content;
+        return root;
       });
     });
   };

--- a/src/svg.js
+++ b/src/svg.js
@@ -1,9 +1,7 @@
 import template from "./template";
 
 export default template(function(string) {
-  var fragment = document.createDocumentFragment(),
-      svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-  svg.innerHTML = string;
-  while (svg.firstChild) fragment.appendChild(svg.firstChild);
-  return fragment;
+  var root = document.createElementNS("http://www.w3.org/2000/svg", "g");
+  root.innerHTML = string;
+  return root;
 });

--- a/src/svg.js
+++ b/src/svg.js
@@ -2,6 +2,6 @@ import template from "./template";
 
 export default template(function(string) {
   var root = document.createElementNS("http://www.w3.org/2000/svg", "g");
-  root.innerHTML = string;
+  root.innerHTML = string.trim();
   return root;
 });

--- a/src/template.js
+++ b/src/template.js
@@ -2,7 +2,7 @@ export default function template(render) {
   return function(strings) {
     var string = strings[0],
         parts = [], part,
-        fragment = null,
+        root = null,
         node, nodes,
         walker,
         i, n, j, m, k = -1;
@@ -17,32 +17,30 @@ export default function template(render) {
         for (j = 0, m = part.length; j < m; ++j) {
           node = part[j];
           if (node instanceof Node) {
-            if (!fragment) {
-              parts[++k] = fragment = document.createDocumentFragment();
+            if (root === null) {
+              parts[++k] = root = document.createDocumentFragment();
               string += "<!--o:" + k + "-->";
             }
-            fragment.appendChild(node);
+            root.appendChild(node);
           } else {
-            if (fragment) {
-              fragment = null;
-            }
+            root = null;
             string += node;
           }
         }
-        fragment = null;
+        root = null;
       } else {
         string += part;
       }
       string += strings[i];
     }
 
-    // Render the document fragment.
-    fragment = render(string);
+    // Render the text.
+    root = render(string);
 
-    // Walk the document fragment to replace comment placeholders.
+    // Walk the rendered content to replace comment placeholders.
     if (++k > 0) {
       nodes = new Array(k);
-      walker = document.createTreeWalker(fragment, NodeFilter.SHOW_COMMENT, null, false);
+      walker = document.createTreeWalker(root, NodeFilter.SHOW_COMMENT, null, false);
       while (walker.nextNode()) {
         node = walker.currentNode;
         if (/^o:/.test(node.nodeValue)) {
@@ -56,9 +54,9 @@ export default function template(render) {
       }
     }
 
-    // If the document fragment is a single node, detach and return the node.
-    return fragment.childNodes.length === 1
-        ? fragment.removeChild(fragment.firstChild)
-        : fragment;
+    // If the rendered content is a single node, detach and return the node.
+    return root.childNodes.length === 1
+        ? root.removeChild(root.firstChild)
+        : root;
   };
 }


### PR DESCRIPTION
Unlike elements, document fragments “dissolve” when they are added to the DOM. Their self-destructive nature makes them difficult to use as stable representations of a fragment of a document; for example, you can add event listeners to a document fragment, but when the document fragment is attached to the DOM, the fragment empties and so the event listeners will never fire.

This restores the previous behavior of the html tagged template literal: if the template literal results in multiple top-level nodes, these nodes are wrapped in an implicit DIV. Likewise, the svg tagged template literal uses an implicit G.