### PR TITLE
Add DOM.uid.

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,33 @@ This is equivalent to:
 document.createTextNode("Hello, world!")
 ```
 
+<a href="#DOM_uid" name="DOM_uid">#</a> DOM.<b>uid</b>([<i>name</i>])
+
+Returns a new unique *identifier*. If *name* is specified, the *identifier*.id will be derived from the specified *name*, which may be useful for debugging. If DOM.uid is called repeatedly with the same *name*, every returned *identifier* is still unique (that is, different). Identifiers are useful in SVG: use *identifier*.href for IRI references, such as the [xlink:href](https://www.w3.org/TR/SVG/animate.html#HrefAttribute) attribute; use *identifier*.toString for functional notation, such as the [clip-path](https://www.w3.org/TR/SVG/masking.html#ClipPathProperty) presentation attribute.
+
+For example, to clip the Mona Lisa to a circle of radius 320px:
+
+```js
+{
+  const clip = uid("clip");
+  return svg`<svg width="640" height="640">
+  <defs>
+    <clipPath id="${clip.id}">
+      <circle cx="320" cy="320" r="320"></circle>
+    </clipPath>
+  </defs>
+  <image
+    clip-path="${clip}"
+    width="640" height="640"
+    preserveAspectRatio="xMidYMin slice"
+    xlink:href="https://raw.githubusercontent.com/mbostock/9511ae067889eefa5537eedcbbf87dab/raw/98449954e2eea4ef96c177759635de49a970e8c6/mona-lisa.jpg"
+  ></image>
+</svg>`;
+}
+```
+
+The use of DOM.uid is strongly recommended over hand-coding as it ensures that your identifiers are still unique if your code is imported into another notebook. Because *identifier*.href and *identifier*.toString return absolute rather than local IRIs, it also works well in conjunction with a notebook’s [base URL](https://developer.mozilla.org/docs/Web/HTML/Element/base).
+
 ### Files
 
 <a href="#Files_buffer" name="Files_buffer">#</a> Files.<b>buffer</b>(<i>file</i>)

--- a/src/dom/index.js
+++ b/src/dom/index.js
@@ -7,6 +7,7 @@ import range from "./range";
 import select from "./select";
 import svg from "./svg";
 import text from "./text";
+import uid from "./uid";
 
 export default {
   canvas: canvas,
@@ -17,5 +18,6 @@ export default {
   range: range,
   select: select,
   svg: svg,
-  text: text
+  text: text,
+  uid: uid
 };

--- a/src/dom/uid.js
+++ b/src/dom/uid.js
@@ -1,0 +1,14 @@
+var count = 0;
+
+export default function(name) {
+  return new Id("O-" + (name == null ? "" : name + "-") + ++count);
+}
+
+function Id(id) {
+  this.id = id;
+  this.href = window.location.href + "#" + id;
+}
+
+Id.prototype.toString = function() {
+  return "url(" + this.href + ")";
+};


### PR DESCRIPTION
For example:

![image](https://user-images.githubusercontent.com/230541/37924484-ce98b67c-30e6-11e8-9305-c4dcf4ef3f69.png)

Fixes two pain points:

1. It’s tedious to generate unique identifiers currently. See the source of [D3 Treemap](https://beta.observablehq.com/@mbostock/d3-treemap) for example, which uses Math.random.

2. The introduction of a base URL to fix anchor links ([forum post](https://talk.observablehq.com/t/bug-report-local-anchor-link/478)) broke local IRIs in Safari. (Firefox and Chrome seem to treat local IRIs as local-to-the-SVG regardless of a base URL.) By using absolute IRIs, we avoid this problem.