### PR TITLE
Part of (compiler-refactor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ If you use NPM, `npm install @observablehq/notebook-stdlib`.
 
 ## API Reference
 
-<a href="#runtimeLibrary" name="runtimeLibrary">#</a> <b>runtimeLibrary</b>([<i>resolve</i>])
+<a href="#Library" name="Library">#</a> <b>Library</b>([<i>resolve</i>])
 
 Returns a new standard library object, defining the following properties:
 
@@ -25,6 +25,10 @@ Returns a new standard library object, defining the following properties:
 * [width](#width) - the current page width.
 
 If *resolve* is specified, it is a function that returns the URL of the module with the specified *name*; this is used internally by [require](#require).
+
+```js
+let standardLibrary = new Library();
+```
 
 ### DOM
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ import svg from "./svg";
 import tex from "./tex";
 import width from "./width";
 
-export function Library(resolve) {
+export default function Library(resolve) {
   if (resolve == null) resolve = resolveDefault;
   var require = requireFrom(resolve);
   Object.defineProperties(this, {

--- a/src/index.js
+++ b/src/index.js
@@ -29,3 +29,5 @@ export default function Library(resolve) {
     width: {value: width, enumerable: true}
   });
 }
+
+export {DOM, Files, Generators, Promises};

--- a/src/index.js
+++ b/src/index.js
@@ -11,21 +11,21 @@ import svg from "./svg";
 import tex from "./tex";
 import width from "./width";
 
-export function runtimeLibrary(resolve) {
+export function Library(resolve) {
   if (resolve == null) resolve = resolveDefault;
   var require = requireFrom(resolve);
-  return {
-    DOM: DOM,
-    Files: Files,
-    Generators: Generators,
-    Promises: Promises,
-    require: constant(require),
-    resolve: constant(resolve),
-    html: constant(html),
-    md: md(require, resolve),
-    svg: constant(svg),
-    tex: tex(require, resolve),
-    now: now,
-    width: width
-  };
+  Object.defineProperties(this, {
+    DOM: {value: DOM, enumerable: true},
+    Files: {value: Files, enumerable: true},
+    Generators: {value: Generators, enumerable: true},
+    Promises: {value: Promises, enumerable: true},
+    require: {value: constant(require), enumerable: true},
+    resolve: {value: constant(resolve), enumerable: true},
+    html: {value: constant(html), enumerable: true},
+    md: {value: md(require, resolve), enumerable: true},
+    svg: {value: constant(svg), enumerable: true},
+    tex: {value: tex(require, resolve), enumerable: true},
+    now: {value: now, enumerable: true},
+    width: {value: width, enumerable: true}
+  });
 }

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,5 +1,6 @@
 import tape from "tape-await";
 import Library from "../src/";
+import {DOM, Files, Generators, Promises} from "../src/";
 
 tape("new Library returns a library with the expected keys", async test => {
   test.deepEqual(Object.keys(new Library()).sort(), [
@@ -16,4 +17,12 @@ tape("new Library returns a library with the expected keys", async test => {
     "tex",
     "width"
   ]);
+});
+
+tape("index.js also exports static values independently of the library", async test => {
+  const library = new Library();
+  test.deepEqual(DOM, library.DOM);
+  test.deepEqual(Files, library.Files);
+  test.deepEqual(Generators, library.Generators);
+  test.deepEqual(Promises, library.Promises);
 });

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,8 +1,8 @@
 import tape from "tape-await";
-import {runtimeLibrary} from "../src/";
+import {Library} from "../src/";
 
-tape("runtimeLibrary() returns a library with the expected keys", async test => {
-  test.deepEqual(Object.keys(runtimeLibrary()).sort(), [
+tape("new Library returns a library with the expected keys", async test => {
+  test.deepEqual(Object.keys(new Library()).sort(), [
     "DOM",
     "Files",
     "Generators",

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,5 +1,5 @@
 import tape from "tape-await";
-import {Library} from "../src/";
+import Library from "../src/";
 
 tape("new Library returns a library with the expected keys", async test => {
   test.deepEqual(Object.keys(new Library()).sort(), [


### PR DESCRIPTION
Only a small change to the standard library:

* Renames `runtimeLibrary` to just plain `Library`, for consistency with **notebook-runtime**.

* Also exports the "static" namespaces from the standard library at the top level, so you can individually import DOM, Files, Generators or Promises if you choose to. (The notebook-runtime uses just Generators).