### PR TITLE
Fix crash in for-of.

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,18 @@ The resolved value is likewise dependent on the *input*.type as follows:
 
 The specified *input* need not be an HTMLInputElement, but it must support the *target*.addEventListener and *target*.removeEventListener methods of the [EventTarget interface](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener).
 
-This generator implementation is used by Observable’s [viewof operator](https://beta.observablehq.com/@mbostock/a-brief-introduction-to-viewof) to define the current value of a view, and is based on [Generators.observe](#Generators_observe). One often does not use Generators.input directly, but it can be used to define a [generator cell](https://beta.observablehq.com/@mbostock/generator-cells-functions-and-objects) exposing the current value of an input.
+This generator implementation is used by Observable’s [viewof operator](https://beta.observablehq.com/@mbostock/a-brief-introduction-to-viewof) to define the current value of a view, and is based on [Generators.observe](#Generators_observe). One often does not use Generators.input directly, but it can be used to define a [generator cell](https://beta.observablehq.com/@mbostock/generator-cells-functions-and-objects) exposing the current value of an input. You can also read the values from the generator by hand. For example, to accumulate the first four values of an input:
+
+```js
+{
+  const values = [];
+  for (const value of Generators.input(element)) {
+    if (values.push(await value) >= 4) {
+      return values;
+    }
+  }
+}
+```
 
 Note that because Generators.observe is lossy, the generator returned by Generators.input is likewise not guaranteed to yield a value for every input event emitted by the *input*; if more than one event is emitted before the next value is pulled from the generator (more than once per animation frame in the Observable runtime), then only the latest value is seen. See [Generators.queue](#Generators_queue) for a non-debouncing generator.
 

--- a/src/generators/disposable.js
+++ b/src/generators/disposable.js
@@ -2,7 +2,7 @@ export default function disposable(value, dispose) {
   let done = false;
   return {
     next: () => done ? {done: true} : (done = true, {done: false, value}),
-    return: x => (done = true, dispose(value), x),
+    return: () => (done = true, dispose(value), {done: true}),
     throw: () => ({done: done = true})
   };
 }

--- a/src/generators/observe.js
+++ b/src/generators/observe.js
@@ -1,4 +1,3 @@
-import noop from "../noop";
 import that from "../that";
 
 export default function(initialize) {
@@ -21,8 +20,8 @@ export default function(initialize) {
 
   return {
     [Symbol.iterator]: that,
-    throw: noop,
-    return: dispose == null ? noop : dispose,
+    throw: () => ({done: true}),
+    return: () => (dispose != null && dispose(), {done: true}),
     next
   };
 }

--- a/src/generators/queue.js
+++ b/src/generators/queue.js
@@ -1,4 +1,3 @@
-import noop from "../noop";
 import that from "../that";
 
 export default function(initialize) {
@@ -20,8 +19,8 @@ export default function(initialize) {
 
   return {
     [Symbol.iterator]: that,
-    throw: noop,
-    return: dispose == null ? noop : dispose,
+    throw: () => ({done: true}),
+    return: () => (dispose != null && dispose(), {done: true}),
     next
   };
 }

--- a/src/noop.js
+++ b/src/noop.js
@@ -1,1 +1,0 @@
-export default function() {}

--- a/test/generators/disposable-test.js
+++ b/test/generators/disposable-test.js
@@ -11,9 +11,8 @@ tape("disposable(value, dispose) yields the specified value", async test => {
 tape("disposable(value, dispose) defines generator.return", async test => {
   let passedFoo;
   const foo = {};
-  const returnValue = {};
   const generator = disposable(foo, _ => passedFoo = _);
-  test.equal(generator.return(returnValue), returnValue);
+  test.deepEqual(generator.return(), {done: true});
   test.equal(passedFoo, foo);
   test.deepEqual(generator.next(), {done: true});
 });


### PR DESCRIPTION
If *iterator*.return doesn’t return an object, then for-of crashes.