### PR TITLE
Update d3-require.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ For examples, see https://beta.observablehq.com/@mbostock/standard-library.
 * [Generators](#generators) - utilities for generators and iterators.
 * [Promises](#promises) - utilities for promises.
 * [require](#require) - load third-party libraries.
-* [resolve](#resolve) - find third-party resources.
 * [html](#html) - render HTML.
 * [md](#markdown) - render Markdown.
 * [svg](#svg) - render SVG.
@@ -711,12 +710,12 @@ d3 = require("d3-array@1.1")
 
 See [d3-require](https://github.com/d3/d3-require) for more information.
 
-<a href="#resolve" name="resolve">#</a> <b>resolve</b>(<i>name</i>) [<>](https://github.com/d3/d3-require/blob/master/index.js "Source")
+<a href="#require_resolve" name="require_resolve">#</a> require.<b>resolve</b>(<i>name</i>) [<>](https://github.com/d3/d3-require/blob/master/index.js "Source")
 
-Returns the resolved URL to require the module with the specified *name*. For example:
+Returns a promise to the resolved URL to require the module with the specified *name*. For example:
 
 ```js
-resolve("d3-array") // "https://unpkg.com/d3-array"
+require.resolve("d3-array") // "https://unpkg.com/d3-array@1.2.1/build/d3-array.js"
 ```
 
 ## Installing

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "cjs": true
   },
   "dependencies": {
-    "esm": "^3.0.5",
-    "d3-require": "^0.6.6"
+    "d3-require": "^1.0.0",
+    "esm": "^3.0.5"
   },
   "devDependencies": {
     "eslint": "^4.12.1",

--- a/src/library.js
+++ b/src/library.js
@@ -14,7 +14,7 @@ import tex from "./tex";
 import width from "./width";
 
 export default function Library(resolver) {
-  var require = resolver == null ? requireFrom(resolver) : requireDefault;
+  var require = resolver == null ? requireDefault : requireFrom(resolver);
   Object.defineProperties(this, {
     DOM: {value: DOM, enumerable: true},
     Files: {value: Files, enumerable: true},

--- a/src/library.js
+++ b/src/library.js
@@ -1,4 +1,4 @@
-import {resolve as resolveDefault, requireFrom} from "d3-require";
+import {require as requireDefault, requireFrom} from "d3-require";
 import constant from "./constant";
 import DOM from "./dom/index";
 import Files from "./files/index";
@@ -8,26 +8,26 @@ import md from "./md";
 import Mutable from "./mutable";
 import now from "./now";
 import Promises from "./promises/index";
+import resolve from "./resolve";
 import svg from "./svg";
 import tex from "./tex";
 import width from "./width";
 
-export default function Library(resolve) {
-  if (resolve == null) resolve = resolveDefault;
-  var require = requireFrom(resolve);
+export default function Library(resolver) {
+  var require = resolver == null ? requireFrom(resolver) : requireDefault;
   Object.defineProperties(this, {
     DOM: {value: DOM, enumerable: true},
     Files: {value: Files, enumerable: true},
     Generators: {value: Generators, enumerable: true},
     html: {value: constant(html), enumerable: true},
-    md: {value: md(require, resolve), enumerable: true},
+    md: {value: md(require), enumerable: true},
     Mutable: {value: constant(Mutable), enumerable: true},
     now: {value: now, enumerable: true},
     Promises: {value: Promises, enumerable: true},
     require: {value: constant(require), enumerable: true},
     resolve: {value: constant(resolve), enumerable: true},
     svg: {value: constant(svg), enumerable: true},
-    tex: {value: tex(require, resolve), enumerable: true},
+    tex: {value: tex(require), enumerable: true},
     width: {value: width, enumerable: true}
   });
 }

--- a/src/resolve.js
+++ b/src/resolve.js
@@ -1,0 +1,6 @@
+export default function resolve(name, base) {
+  if (/^(\w+:)|\/\//i.test(name)) return name;
+  if (/^[.]{0,2}\//i.test(name)) return new URL(name, base == null ? location : base).href;
+  if (!name.length || /^[\s._]/.test(name) || /\s$/.test(name)) throw new Error("illegal name");
+  return "https://unpkg.com/" + name;
+}

--- a/src/tex.js
+++ b/src/tex.js
@@ -15,7 +15,7 @@ export default function(require, resource) {
   return function() {
     return Promise.all([
       require("katex@0.9.0/dist/katex.min.js"),
-      style(resource("katex@0.9.0/dist/katex.min.css"))
+      resource("katex@0.9.0/dist/katex.min.css").then(style)
     ]).then(function(values) {
       var katex = values[0], tex = renderer();
 

--- a/src/tex.js
+++ b/src/tex.js
@@ -11,11 +11,11 @@ function style(href) {
   });
 }
 
-export default function(require, resource) {
+export default function(require) {
   return function() {
     return Promise.all([
       require("katex@0.9.0/dist/katex.min.js"),
-      resource("katex@0.9.0/dist/katex.min.css").then(style)
+      require.resolve("katex@0.9.0/dist/katex.min.css").then(style)
     ]).then(function(values) {
       var katex = values[0], tex = renderer();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -272,9 +272,9 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   dependencies:
     cssom "0.3.x"
 
-d3-require@^0.6.6:
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/d3-require/-/d3-require-0.6.6.tgz#cb01119b13d85c81aec97b2f88051731e89bf469"
+d3-require@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/d3-require/-/d3-require-1.0.0.tgz#9831bfc5db3e4bcc6c50b3d5f3e40339eeedece7"
 
 dashdash@^1.12.0:
   version "1.14.1"


### PR DESCRIPTION
This introduces the async require.resolve while deprecating resolve.

(I will update the package.json and yarn.lock when d3/d3-require#10 is merged and released.)