### PR TITLE
Tweak Katex styles.

### DIFF
--- a/src/tex.js
+++ b/src/tex.js
@@ -14,8 +14,8 @@ function style(href) {
 export default function(require) {
   return function() {
     return Promise.all([
-      require("@observablehq/katex@0.9.1/dist/katex.min.js"),
-      require.resolve("@observablehq/katex@0.9.1/dist/katex.min.css").then(style)
+      require("@observablehq/katex@0.9.2/dist/katex.min.js"),
+      require.resolve("@observablehq/katex@0.9.2/dist/katex.min.css").then(style)
     ]).then(function(values) {
       var katex = values[0], tex = renderer();
 

--- a/src/tex.js
+++ b/src/tex.js
@@ -14,8 +14,8 @@ function style(href) {
 export default function(require) {
   return function() {
     return Promise.all([
-      require("katex@0.9.0/dist/katex.min.js"),
-      require.resolve("katex@0.9.0/dist/katex.min.css").then(style)
+      require("@observablehq/katex@0.9.1/dist/katex.min.js"),
+      require.resolve("@observablehq/katex@0.9.1/dist/katex.min.css").then(style)
     ]).then(function(values) {
       var katex = values[0], tex = renderer();
 

--- a/src/tex.js
+++ b/src/tex.js
@@ -14,8 +14,8 @@ function style(href) {
 export default function(require) {
   return function() {
     return Promise.all([
-      require("@observablehq/katex@0.9.2/dist/katex.min.js"),
-      require.resolve("@observablehq/katex@0.9.2/dist/katex.min.css").then(style)
+      require("@observablehq/katex@0.10.0/dist/katex.min.js"),
+      require.resolve("@observablehq/katex@0.10.0/dist/katex.min.css").then(style)
     ]).then(function(values) {
       var katex = values[0], tex = renderer();
 


### PR DESCRIPTION
Rather than overriding the styles in the UI, patch the KaTeX distribution to include our preferred styles directly. For the patched distribution, see:

https://github.com/observablehq/katex