### PR TITLE
Add require.alias.

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,6 +719,30 @@ Returns a promise to the resolved URL to require the module with the specified *
 require.resolve("d3-array") // "https://unpkg.com/d3-array@1.2.1/build/d3-array.js"
 ```
 
+<a href="#require_alias" name="require_alias">#</a> require.<b>alias</b>(<i>aliases</i>) [<>](https://github.com/d3/d3-require/blob/master/index.js "Source")
+
+Returns a [*require*](#require) function with the specified *aliases*. For each key in the specified *aliases* object, any require of that key is substituted with the corresponding value. For example, to declare UMD bundles and pin versions:
+
+```js
+r = require.alias({
+  "react": "react@16/umd/react.production.min.js",
+  "react-dom": "react-dom@16/umd/react-dom.production.min.js",
+  "semiotic": "semiotic@1"
+})
+```
+
+Then to require the libraries:
+
+```js
+React = r("react")
+```
+```js
+ReactDOM = r("react-dom")
+```
+```js
+Semiotic = r("semiotic")
+```
+
 ## Installing
 
 The Observable notebook standard library is built-in to Observable, so you don’t normally need to install or instantiate it directly. If you use NPM, `npm install @observablehq/notebook-stdlib`.

--- a/README.md
+++ b/README.md
@@ -721,7 +721,7 @@ require.resolve("d3-array") // "https://unpkg.com/d3-array@1.2.1/build/d3-array.
 
 <a href="#require_alias" name="require_alias">#</a> require.<b>alias</b>(<i>aliases</i>) [<>](https://github.com/d3/d3-require/blob/master/index.js "Source")
 
-Returns a [*require*](#require) function with the specified *aliases*. For each key in the specified *aliases* object, any require of that key is substituted with the corresponding value. For example, to declare UMD bundles and pin versions:
+Returns a [require function](#require) with the specified *aliases*. For each key in the specified *aliases* object, any require of that key is substituted with the corresponding value. For example, to declare UMD bundles and pin versions:
 
 ```js
 r = require.alias({

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,10 @@ function config(output) {
     input: "src/index.js",
     plugins: [
       node(),
-      uglify({output: {preamble: copyright}})
+      uglify({
+        toplevel: output.format === "es",
+        output: {preamble: copyright}
+      })
     ],
     output
   };

--- a/src/library.js
+++ b/src/library.js
@@ -1,4 +1,3 @@
-import {require as requireDefault, requireFrom} from "d3-require";
 import constant from "./constant";
 import DOM from "./dom/index";
 import Files from "./files/index";
@@ -9,13 +8,13 @@ import Mutable from "./mutable";
 import now from "./now";
 import Promises from "./promises/index";
 import resolve from "./resolve";
+import requirer from "./require";
 import svg from "./svg";
 import tex from "./tex";
 import width from "./width";
 
 export default function Library(resolver) {
-  const require = resolver == null ? requireDefault : requireFrom(resolver);
-  require.alias = requireAlias(require.resolve);
+  const require = requirer(resolver);
   Object.defineProperties(this, {
     DOM: {value: DOM, enumerable: true},
     Files: {value: Files, enumerable: true},
@@ -31,8 +30,4 @@ export default function Library(resolver) {
     tex: {value: tex(require), enumerable: true},
     width: {value: width, enumerable: true}
   });
-}
-
-function requireAlias(resolve) {
-  return map => requireFrom(name => resolve(name in map ? map[name] : name));
 }

--- a/src/library.js
+++ b/src/library.js
@@ -14,7 +14,8 @@ import tex from "./tex";
 import width from "./width";
 
 export default function Library(resolver) {
-  var require = resolver == null ? requireDefault : requireFrom(resolver);
+  const require = resolver == null ? requireDefault : requireFrom(resolver);
+  require.alias = requireAlias(require.resolve);
   Object.defineProperties(this, {
     DOM: {value: DOM, enumerable: true},
     Files: {value: Files, enumerable: true},
@@ -30,4 +31,8 @@ export default function Library(resolver) {
     tex: {value: tex(require), enumerable: true},
     width: {value: width, enumerable: true}
   });
+}
+
+function requireAlias(resolve) {
+  return map => requireFrom(name => resolve(name in map ? map[name] : name));
 }

--- a/src/require.js
+++ b/src/require.js
@@ -1,7 +1,7 @@
 import {require as requireDefault, requireFrom} from "d3-require";
 
-export default function(resolver) {
-  const require = resolver == null ? requireDefault : requireFrom(resolver);
+export default function(resolve) {
+  const require = resolve == null ? requireDefault : requireFrom(resolve);
   require.alias = requireAlias(require.resolve);
   return require;
 }

--- a/src/require.js
+++ b/src/require.js
@@ -1,0 +1,13 @@
+import {require as requireDefault, requireFrom} from "d3-require";
+
+export default function(resolver) {
+  const require = resolver == null ? requireDefault : requireFrom(resolver);
+  require.alias = requireAlias(require.resolve);
+  return require;
+}
+
+function requireAlias(resolve) {
+  return map => requireFrom((name, base) => {
+    return resolve(name in map ? map[name] : name, base);
+  });
+}


### PR DESCRIPTION
For example, to declare React’s missing UMD entry:

```js
react = require.alias({
  react: "react/umd/react.production.min.js"
})("react")
```

You can also use this to pin exact versions.