### PR TITLE
Update highlight dependency to highlight Observable keywords and builtins

### DIFF
--- a/src/md.js
+++ b/src/md.js
@@ -7,7 +7,7 @@ export default function(require) {
         var root = document.createElement("div");
         root.innerHTML = marked(string, {langPrefix: ""}).trim();
         var code = root.querySelectorAll("pre code[class]");
-        if (code.length > 0) require("@observablehq/highlight.js@1.0.0/highlight.min.js").then(function(hl) { code.forEach(hl.highlightBlock); });
+        if (code.length > 0) require("@observablehq/highlight.js@1.1.0/highlight.min.js").then(function(hl) { code.forEach(hl.highlightBlock); });
         return root;
       }, function() {
         return document.createElement("div");


### PR DESCRIPTION
This will require an upstream PR to notebook-runtime. I've tested notebook-runtime to confirm that that'll be seamless.

The gist is that, for tutorials and similar content, we'll want `viewof` and `mutable` to highlighted keywords. Right now they're unrecognized by highlight.js.