### PR TITLE
Set xml:base attribute.

### DIFF
--- a/src/dom/svg.js
+++ b/src/dom/svg.js
@@ -3,5 +3,6 @@ export default function(width, height) {
   svg.setAttribute("viewBox", [0, 0, width, height]);
   svg.setAttribute("width", width);
   svg.setAttribute("height", height);
+  svg.setAttributeNS("http://www.w3.org/XML/1998/namespace", "base", window.location.href);
   return svg;
 }


### PR DESCRIPTION
On broken browsers such as Firefox and Safari <12, this fixes same-page fragment identifiers (such as for text paths and gradients) without requiring DOM.uid.