### PR TITLE
Differentiate marked-generated pre elements by adding a class to them.

### DIFF
--- a/src/md.js
+++ b/src/md.js
@@ -7,7 +7,14 @@ export default function(require) {
         var root = document.createElement("div");
         root.innerHTML = marked(string, {langPrefix: ""}).trim();
         var code = root.querySelectorAll("pre code[class]");
-        if (code.length > 0) require("@observablehq/highlight.js@1.1.1/highlight.min.js").then(function(hl) { code.forEach(hl.highlightBlock); });
+        if (code.length > 0) {
+          require("@observablehq/highlight.js@1.1.1/highlight.min.js").then(function(hl) {
+            code.forEach(function (block) {
+              hl.highlightBlock(block);
+              block.parentNode.classList.add('observablehq--md-pre');
+            });
+          });
+        }
         return root;
       }, function() {
         return document.createElement("div");


### PR DESCRIPTION
Upstream, I want to help out mobile / smallscreen users by allowing code blocks to scroll horizontally. Right now any wide code block on a mobile phone is simply cut off.

But I want to do this in a way that's unlikely to break existing notebooks - for example, if someone is using a `pre` element in the output from a `html` tagged template. So this change attaches a class name to the `pre` element in Markdown output only.